### PR TITLE
restore gen jets

### DIFF
--- a/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAODuncorrjet_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/candidateBtaggingMiniAODuncorrjet_cff.py
@@ -2,6 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 ak2PFJets = ak4PFJets.clone(jetPtMin = 1.0, rParam = 0.2, src = 'packedPFCandidates')
+from RecoJets.Configuration.RecoGenJets_cff import ak4GenJetsNoNu
+ak2GenJetsNoNuNonAgg = ak4GenJetsNoNu.clone(src = 'packedGenParticlesSignal', rParam = 0.2)
+from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import patJetGenJetMatch
+ak2PatJetGenJetMatch = patJetGenJetMatch.clone(src = "ak2PFJets", matched = "ak2GenJetsNoNuNonAgg", maxDeltaR = 0.2)
 from RecoBTag.ImpactParameter.pfImpactParameterTagInfos_cfi import pfImpactParameterTagInfos
 pfImpactParameterTagInfos.jets = "ak2PFJets"
 pfImpactParameterTagInfos.candidates = "packedPFCandidates"
@@ -30,11 +34,12 @@ ak2PFpatJets = patJets.clone(
     jetSource = "ak2PFJets",
     tagInfoSources = cms.VInputTag('pfImpactParameterTagInfos','pfInclusiveSecondaryVertexFinderTagInfos'),
     discriminatorSources = cms.VInputTag("pfJetProbabilityBJetTags"),
+    genJetMatch = cms.InputTag("ak2PatJetGenJetMatch"),
     JetFlavourInfoSource = "ak2JetFlavourInfos", 
     addAssociatedTracks = False,
     addJetCorrFactors = False,
     addGenPartonMatch = False,
-    addGenJetMatch = False,
+    addGenJetMatch = True,
     addDiscriminators = True,
     getJetMCFlavour = True,
     useLegacyJetMCFlavour = False,
@@ -47,6 +52,8 @@ ak2PFpatJets = patJets.clone(
 unsubCandidateBtagging = cms.Sequence(
     ak2PFJets +
     hiSignalGenParticles +
+    ak2GenJetsNoNuNonAgg +
+    ak2PatJetGenJetMatch +
     selectedHadronsAndPartons +
     ak2JetFlavourInfos +
     pfImpactParameterTagInfos +

--- a/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
+++ b/HeavyIonsAnalysis/JetAnalysis/python/clusterJetsFromMiniAOD_cff.py
@@ -45,7 +45,7 @@ def setupHeavyIonJets(tag, sequence, process, isMC, radius = -1, JECTag = 'None'
                           matched = 'hiSignalGenParticles',
                           src = tag+'Jets'),
                        process, sequence)
-
+        
         genjetcollection = 'ak'+str(radiustag)+'GenJetsNoNu'
 
         addToSequence( genjetcollection,


### PR DESCRIPTION
Add back genJets to unsubtracted pat sequence.
For now the gen-level aggregation operates on the matched gen jets in the pat jet collection, but it could just as well operate on the original gen jet collection.
The gen jets are reconstructed a 2nd time with the aggregated input.  
This is used for the Cs jet pat jet collection 